### PR TITLE
Support dotnet tools flags

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,18 +16,32 @@ env:
   GOLANG_VERSION: "1.16"
 
 jobs:
-  lint:
-    name: Linting
+  doc:
+    name: Check doc freshness
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Lint
-      uses: golangci/golangci-lint-action@v2
+    - name: Setup Golang
+      uses: actions/setup-go@v2
       with:
-        version: v1.36
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        args: "--tests=false"
+        go-version: ${{ env.GOLANG_VERSION }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Run tidy
+      run: |
+        make doc
+    - name: Check if working tree is dirty
+      run: |
+        if [[ $(git diff --stat) != '' ]]; then
+          git diff
+          echo 'run `make doc` or `make prepare` and commit changes'
+          exit 1
+        fi
 
   format:
     name: Formatting
@@ -41,6 +55,19 @@ jobs:
         version: v1.36
         github-token: ${{ secrets.GITHUB_TOKEN }}
         args: "--disable-all -E golint,goimports,misspell"
+
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.36
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        args: "--tests=false"
 
   tidy:
     name: Mod tidy
@@ -58,9 +85,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Install dependencies
-      run: |
-        go mod download
     - name: Run tidy
       run: |
         make tidy
@@ -68,7 +92,7 @@ jobs:
       run: |
         if [[ $(git diff --stat) != '' ]]; then
           git diff
-          echo 'run `go mod tidy` and commit changes'
+          echo 'run `make tidy` or `make prepare` and commit changes'
           exit 1
         fi
 
@@ -88,9 +112,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Install dependencies
-      run: |
-        go mod download
     - name: Run tests
       run: |
         make test-unit
@@ -99,8 +120,9 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     needs:
-    - lint
+    - doc
     - format
+    - lint
     - tidy
     - test
     steps:
@@ -116,9 +138,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Install dependencies
-      run: |
-        go mod download
     - name: Setup Kubernetes
       uses: engineerd/setup-kind@v0.5.0
       with:
@@ -132,10 +151,6 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     needs:
-    - lint
-    - format
-    - tidy
-    - test
     - integration-tests
     steps:
     - name: Checkout
@@ -150,9 +165,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Install dependencies
-      run: |
-        go mod download
     - name: Build dumper
       working-directory: ./dumper
       run: |
@@ -173,10 +185,6 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     needs:
-    - lint
-    - format
-    - tidy
-    - test
     - integration-tests
     steps:
     - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,23 @@
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+.PHONY: all
+all: help
+
+.PHONY: doc
+doc:
+	./hacks/run-doc-generation.sh
+
+.PHONY: lint
+lint:
+	golangci-lint run --tests=false
+	golangci-lint run --disable-all -E golint,goimports,misspell
+
+.PHONY: prepare
+prepare: tidy lint doc test
+
 .PHONY: setup
 setup:
 	kind create cluster
@@ -17,7 +37,18 @@ test-integration:
 tidy:
 	go mod tidy -v
 
-.PHONY: lint
-lint:
-	golangci-lint run --tests=false
-	golangci-lint run --disable-all -E golint,goimports,misspell
+.PHONY: help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@echo "  ${YELLOW}doc              ${RESET} Run doc generation"
+	@echo "  ${YELLOW}lint             ${RESET} Run linters via golangci-lint"
+	@echo "  ${YELLOW}prepare          ${RESET} Run all available checks and generators"
+	@echo "  ${YELLOW}setup            ${RESET} Setup local environment. Create kind cluster"
+	@echo "  ${YELLOW}test             ${RESET} Run all available tests"
+	@echo "  ${YELLOW}test-integration ${RESET} Run all integration tests"
+	@echo "  ${YELLOW}test-unit        ${RESET} Run all unit tests"
+	@echo "  ${YELLOW}tidy             ${RESET} Run tidy for go module to remove unused dependencies"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ RESET  := $(shell tput -Txterm sgr0)
 .PHONY: all
 all: help
 
+.PHONY: cover
+cover:
+	go tool cover -html ./cover.out
+
 .PHONY: doc
 doc:
 	./hacks/run-doc-generation.sh
@@ -44,6 +48,7 @@ help:
 	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
 	@echo ''
 	@echo 'Targets:'
+	@echo "  ${YELLOW}cover            ${RESET} Open html coverage report in browser"
 	@echo "  ${YELLOW}doc              ${RESET} Run doc generation"
 	@echo "  ${YELLOW}lint             ${RESET} Run linters via golangci-lint"
 	@echo "  ${YELLOW}prepare          ${RESET} Run all available checks and generators"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Or trace:
 kubectl shovel trace --pod-name pod-name-74df554df7-qldq7 -o ./trace.nettrace
 ```
 
+Most of dotnet tools flags supported as well to use, e.g `--duration` and `--format` for `trace`.
 You can find more info and examples in [cli documentation](./cli/docs/kubectl-shovel.md) or by using `-h/--help` flag.
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ So it requires permissions to get pods and create jobs and allowance to mount `/
 
 ## Development
 
+To run all kinds of checks and generators please use:
+
+```
+make prepare
+```
+
 ### Prerequisites
 
 * golang

--- a/cli/cmd/common_options.go
+++ b/cli/cmd/common_options.go
@@ -20,16 +20,16 @@ type commonOptions struct {
 }
 
 func (options *commonOptions) newCommonFlags(tool string) *pflag.FlagSet {
-	flags := pflag.NewFlagSet("common", pflag.ExitOnError)
-	flags.StringVar(
+	flagSet := pflag.NewFlagSet("common", pflag.ExitOnError)
+	flagSet.StringVar(
 		&options.podName,
 		"pod-name",
 		options.podName,
 		"Target pod",
 	)
-	panicOnError(cobra.MarkFlagRequired(flags, "pod-name"))
+	panicOnError(cobra.MarkFlagRequired(flagSet, "pod-name"))
 
-	flags.StringVarP(
+	flagSet.StringVarP(
 		&options.containerName,
 		"container",
 		"c",
@@ -37,7 +37,7 @@ func (options *commonOptions) newCommonFlags(tool string) *pflag.FlagSet {
 		"Target container in pod. Required if pod run multiple containers",
 	)
 
-	flags.StringVarP(
+	flagSet.StringVarP(
 		&options.output,
 		"output",
 		"o",
@@ -48,7 +48,7 @@ func (options *commonOptions) newCommonFlags(tool string) *pflag.FlagSet {
 		"Output file",
 	)
 
-	flags.StringVar(
+	flagSet.StringVar(
 		&options.image,
 		"image",
 		strings.Join(
@@ -61,7 +61,7 @@ func (options *commonOptions) newCommonFlags(tool string) *pflag.FlagSet {
 		"Image of dumper to use for job",
 	)
 	options.kubeFlags = genericclioptions.NewConfigFlags(false)
-	options.kubeFlags.AddFlags(flags)
+	options.kubeFlags.AddFlags(flagSet)
 
-	return flags
+	return flagSet
 }

--- a/cli/cmd/common_options.go
+++ b/cli/cmd/common_options.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,10 +42,10 @@ func (options *commonOptions) newCommonFlags(tool string) *pflag.FlagSet {
 		&options.output,
 		"output",
 		"o",
-		"./"+
-			currentTime()+
-			"."+
+		fmt.Sprintf(
+			"./output.%s",
 			tool,
+		),
 		"Output file",
 	)
 

--- a/cli/cmd/gcdump.go
+++ b/cli/cmd/gcdump.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/dodopizza/kubectl-shovel/internal/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -13,6 +14,7 @@ const (
 
 type gcDumpOptions struct {
 	*commonOptions
+	*flags.GCDumpFlagSet
 }
 
 func newGCDumpCommand() *cobra.Command {
@@ -43,15 +45,19 @@ func newGCDumpCommand() *cobra.Command {
 }
 
 func (options *gcDumpOptions) parseFlags() *pflag.FlagSet {
-	flags := pflag.NewFlagSet(gcDumpToolName, pflag.ExitOnError)
-	flags.AddFlagSet(options.commonOptions.newCommonFlags(gcDumpToolName))
+	flagSet := pflag.NewFlagSet(gcDumpToolName, pflag.ExitOnError)
+	flagSet.AddFlagSet(options.commonOptions.newCommonFlags(gcDumpToolName))
 
-	return flags
+	options.GCDumpFlagSet = flags.NewGCDumpFlagSet()
+	flagSet.AddFlagSet(options.GCDumpFlagSet.Parse())
+
+	return flagSet
 }
 
 func (options *gcDumpOptions) makeGCDump() error {
 	return run(
 		options.commonOptions,
 		gcDumpToolName,
+		options.Args()...,
 	)
 }

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -19,7 +19,6 @@ func newJobName() string {
 		[]string{
 			pluginName,
 			uuid.NewString(),
-			currentTime(),
 		},
 		"-",
 	)

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -21,11 +19,5 @@ func newJobName() string {
 			uuid.NewString(),
 		},
 		"-",
-	)
-}
-
-func currentTime() string {
-	return strconv.Itoa(
-		int(time.Now().Unix()),
 	)
 }

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -9,7 +9,7 @@ import (
 )
 
 func handleLogs(readCloser io.ReadCloser) (string, error) {
-	eventsChan := make(chan string)
+	eventsChan := make(chan string, 1)
 
 	go func() {
 		defer readCloser.Close()

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -59,8 +60,10 @@ func run(
 	}
 
 	op := watchdog.NewOperator(k8s, jobPodName)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		if err := op.Run(); err != nil {
+		if err := op.Run(ctx); err != nil {
 			fmt.Println(err)
 		}
 	}()

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -12,6 +12,7 @@ import (
 func run(
 	options *commonOptions,
 	tool string,
+	args ...string,
 ) error {
 	k8s, err := kubernetes.NewClient(options.kubeFlags)
 	if err != nil {
@@ -34,18 +35,19 @@ func run(
 	jobVolume := kubernetes.NewJobVolume(containerInfo)
 
 	fmt.Println("Spawning diagnostics job")
+	args = append([]string{
+		tool,
+		"--container-id",
+		containerInfo.ID,
+		"--container-runtime",
+		containerInfo.Runtime,
+	}, args...)
 	if err := k8s.RunJob(
 		jobName,
 		options.image,
 		pod.Spec.NodeName,
 		jobVolume,
-		[]string{
-			tool,
-			"--container-id",
-			containerInfo.ID,
-			"--container-runtime",
-			containerInfo.Runtime,
-		},
+		args,
 	); err != nil {
 		return err
 	}

--- a/cli/cmd/trace.go
+++ b/cli/cmd/trace.go
@@ -31,7 +31,7 @@ func newTraceCommand() *cobra.Command {
 			"\t* https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace",
 		Example: fmt.Sprintf(examplesTemplate, traceToolName) + "\n\n" +
 			"Use `--duration` to define duration of trace to 30 seconds:\n\n" +
-			"\tkubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --duration 00:00:00:30\n\n" +
+			"\tkubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --duration 30s\n\n" +
 			"Use `--format` to specify Speedscope format:\n\n" +
 			"\tkubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --format Speedscope\n\n" +
 			"And then you can analyze it with https://www.speedscope.app/\n" +

--- a/cli/cmd/trace.go
+++ b/cli/cmd/trace.go
@@ -24,15 +24,19 @@ func newTraceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trace [flags]",
 		Short: "Get dotnet-trace results",
-		Long: "This subcommand will capture 10 seconds of runtime events with dotnet-trace tool for running in k8s appplication.\n" +
+		Long: "This subcommand will capture runtime events with dotnet-trace tool for running in k8s appplication.\n" +
 			"Result will be saved locally in nettrace format so you'll be able to convert it and analyze with appropriate tools.\n" +
 			"You can find more info about dotnet-trace tool by the following links:\n\n" +
 			"\t* https://github.com/dotnet/diagnostics/blob/master/documentation/dotnet-trace-instructions.md\n" +
 			"\t* https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace",
 		Example: fmt.Sprintf(examplesTemplate, traceToolName) + "\n\n" +
-			"One of the resulting trace usage examples is converting it to speedscope format:\n\n" +
-			"\tdotnet trace convert myapp.trace --format Speedscope\n\n" +
-			"And then analyzing it with https://www.speedscope.app/",
+			"Use `--duration` to define duration of trace to 30 seconds:\n\n" +
+			"\tkubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --duration 00:00:00:30\n\n" +
+			"Use `--format` to specify Speedscope format:\n\n" +
+			"\tkubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --format Speedscope\n\n" +
+			"And then you can analyze it with https://www.speedscope.app/\n" +
+			"Or convert any other format to speedscope format with:\n\n" +
+			"\tdotnet trace convert myapp.trace --format Speedscope",
 		RunE: func(*cobra.Command, []string) error {
 			return options.makeTrace()
 		},

--- a/cli/cmd/trace.go
+++ b/cli/cmd/trace.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/dodopizza/kubectl-shovel/internal/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -13,6 +14,7 @@ const (
 
 type traceOptions struct {
 	*commonOptions
+	*flags.TraceFlagSet
 }
 
 func newTraceCommand() *cobra.Command {
@@ -46,15 +48,19 @@ func newTraceCommand() *cobra.Command {
 }
 
 func (options *traceOptions) parseFlags() *pflag.FlagSet {
-	flags := pflag.NewFlagSet(traceToolName, pflag.ExitOnError)
-	flags.AddFlagSet(options.commonOptions.newCommonFlags(traceToolName))
+	flagSet := pflag.NewFlagSet(traceToolName, pflag.ExitOnError)
+	flagSet.AddFlagSet(options.commonOptions.newCommonFlags(traceToolName))
 
-	return flags
+	options.TraceFlagSet = flags.NewTraceFlagSet()
+	flagSet.AddFlagSet(options.TraceFlagSet.Parse())
+
+	return flagSet
 }
 
 func (options *traceOptions) makeTrace() error {
 	return run(
 		options.commonOptions,
 		traceToolName,
+		options.Args()...,
 	)
 }

--- a/cli/docs/kubectl-shovel.md
+++ b/cli/docs/kubectl-shovel.md
@@ -2,10 +2,6 @@
 
 Get diagnostics from running in k8s dotnet application
 
-### Synopsis
-
-Get diagnostics from running in k8s dotnet application
-
 ### Options
 
 ```

--- a/cli/docs/kubectl-shovel_gcdump.md
+++ b/cli/docs/kubectl-shovel_gcdump.md
@@ -48,12 +48,15 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output file (default "./1617127716.gcdump")
+  -o, --output string                  Output file (default "./output.gcdump")
       --pod-name string                Target pod
   -p, --process-id int                 The process ID to collect the trace from (default 1)
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-      --timeout int                    Give up on collecting the GC dump if it takes longer than this many seconds (default 30)
+      --timeout timeout                Give up on collecting the GC dump if it takes longer than this many seconds.
+                                       Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                                       Will be rounded to seconds. If no unit provided defaults to seconds.
+                                       (default 30 sec)
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/cli/docs/kubectl-shovel_gcdump.md
+++ b/cli/docs/kubectl-shovel_gcdump.md
@@ -41,16 +41,19 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+  -c, --container string               Target container in pod. Required if pod run multiple containers
       --context string                 The name of the kubeconfig context to use
   -h, --help                           help for gcdump
       --image string                   Image of dumper to use for job (default "dodopizza/kubectl-shovel-dumper:undefined")
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output file (default "./1609409397.gcdump")
+  -o, --output string                  Output file (default "./1617126796.gcdump")
       --pod-name string                Target pod
+  -p, --process-id int                 The process ID to collect the trace from (default 1)
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
+      --timeout int                    Give up on collecting the GC dump if it takes longer than this many seconds (default 30)
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/cli/docs/kubectl-shovel_gcdump.md
+++ b/cli/docs/kubectl-shovel_gcdump.md
@@ -48,7 +48,7 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output file (default "./1617126796.gcdump")
+  -o, --output string                  Output file (default "./1617127716.gcdump")
       --pod-name string                Target pod
   -p, --process-id int                 The process ID to collect the trace from (default 1)
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")

--- a/cli/docs/kubectl-shovel_gcdump.md
+++ b/cli/docs/kubectl-shovel_gcdump.md
@@ -36,7 +36,7 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "/Users/signal/.kube/cache")
+      --cache-dir string               Default cache directory (default "/home/user/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/cli/docs/kubectl-shovel_trace.md
+++ b/cli/docs/kubectl-shovel_trace.md
@@ -32,7 +32,7 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
 
 Use `--duration` to define duration of trace to 30 seconds:
 
-	kubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --duration 00:00:00:30
+	kubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --duration 30s
 
 Use `--format` to specify Speedscope format:
 

--- a/cli/docs/kubectl-shovel_trace.md
+++ b/cli/docs/kubectl-shovel_trace.md
@@ -4,7 +4,7 @@ Get dotnet-trace results
 
 ### Synopsis
 
-This subcommand will capture 10 seconds of runtime events with dotnet-trace tool for running in k8s appplication.
+This subcommand will capture runtime events with dotnet-trace tool for running in k8s appplication.
 Result will be saved locally in nettrace format so you'll be able to convert it and analyze with appropriate tools.
 You can find more info about dotnet-trace tool by the following links:
 
@@ -30,11 +30,18 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
 
 	kubectl shovel trace --pod-name my-app-65c4fc589c-gznql -n default
 
-One of the resulting trace usage examples is converting it to speedscope format:
+Use `--duration` to define duration of trace to 30 seconds:
+
+	kubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --duration 00:00:00:30
+
+Use `--format` to specify Speedscope format:
+
+	kubectl shovel trace --pod-name my-app-65c4fc589c-gznql -o ./myapp.trace --format Speedscope
+
+And then you can analyze it with https://www.speedscope.app/
+Or convert any other format to speedscope format with:
 
 	dotnet trace convert myapp.trace --format Speedscope
-
-And then analyzing it with https://www.speedscope.app/
 ```
 
 ### Options
@@ -63,7 +70,7 @@ And then analyzing it with https://www.speedscope.app/
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output file (default "./1617126796.trace")
+  -o, --output string                  Output file (default "./1617127716.trace")
       --pod-name string                Target pod
   -p, --process-id int                 The process ID to collect the trace from (default 1)
       --profile profile                A named pre-defined set of provider configurations that allowscommon tracing scenarios to be specified succinctly.

--- a/cli/docs/kubectl-shovel_trace.md
+++ b/cli/docs/kubectl-shovel_trace.md
@@ -42,19 +42,46 @@ And then analyzing it with https://www.speedscope.app/
 ```
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --buffersize int                 Sets the size of the in-memory circular buffer, in megabytes (default 256)
       --cache-dir string               Default cache directory (default "/Users/signal/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
+      --clreventlevel clreventlevel    Verbosity of CLR events to be emitted. Supported levels:
+                                       logalways, critical, error, warning, informational, verbose
+      --clrevents clrevents            A list of CLR runtime provider keywords to enable separated by "+" signs.
+                                       This is a simple mapping that lets you specify event keywords via string aliases rather than their hex values.
+                                       More info here: https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace#options-1
       --cluster string                 The name of the kubeconfig cluster to use
+  -c, --container string               Target container in pod. Required if pod run multiple containers
       --context string                 The name of the kubeconfig context to use
+      --duration duration              Trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss (default 00:00:00:10)
+      --format format                  Sets the output format for the trace file conversion. Supported formats:
+                                       NetTrace, Chromium, Speedscope (default "NetTrace")
   -h, --help                           help for trace
       --image string                   Image of dumper to use for job (default "dodopizza/kubectl-shovel-dumper:undefined")
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output file (default "./1609409397.trace")
+  -o, --output string                  Output file (default "./1617126796.trace")
       --pod-name string                Target pod
+  -p, --process-id int                 The process ID to collect the trace from (default 1)
+      --profile profile                A named pre-defined set of provider configurations that allowscommon tracing scenarios to be specified succinctly.
+                                       The following profiles are available:
+                                       cpu-sampling, gc-verbose, gc-collect
+      --providers providers            A comma-separated list of EventPipe providers to be enabled.
+                                       These providers supplement any providers implied by --profile <profile-name>.
+                                       If there's any inconsistency for a particular provider,
+                                       this configuration takes precedence over the implicit configuration from the profile.
+                                       
+                                       This list of providers is in the form:
+                                       
+                                       * Provider[,Provider]
+                                       * Provider is in the form: KnownProviderName[:Flags[:Level][:KeyValueArgs]].
+                                       * KeyValueArgs is in the form: [key1=value1][;key2=value2].
+                                       
+                                       To learn more about some of the well-known providers in .NET, refer to:
+                                       https://docs.microsoft.com/en-us/dotnet/core/diagnostics/well-known-event-providers
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used

--- a/cli/docs/kubectl-shovel_trace.md
+++ b/cli/docs/kubectl-shovel_trace.md
@@ -50,7 +50,7 @@ Or convert any other format to speedscope format with:
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --buffersize int                 Sets the size of the in-memory circular buffer, in megabytes (default 256)
-      --cache-dir string               Default cache directory (default "/Users/signal/.kube/cache")
+      --cache-dir string               Default cache directory (default "/home/user/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS

--- a/cli/docs/kubectl-shovel_trace.md
+++ b/cli/docs/kubectl-shovel_trace.md
@@ -62,7 +62,7 @@ Or convert any other format to speedscope format with:
       --cluster string                 The name of the kubeconfig cluster to use
   -c, --container string               Target container in pod. Required if pod run multiple containers
       --context string                 The name of the kubeconfig context to use
-      --duration duration              Trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss (default 00:00:00:10)
+      --duration duration              Trace for the given timespan and then automatically stop the trace.Provided in the form of dd:hh:mm:ss or corresponding time unit representation (e.g. 1s, 2m, 3h) (default 10s) (default 00:00:00:10)
       --format format                  Sets the output format for the trace file conversion. Supported formats:
                                        NetTrace, Chromium, Speedscope (default "NetTrace")
   -h, --help                           help for trace
@@ -70,7 +70,7 @@ Or convert any other format to speedscope format with:
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output file (default "./1617127716.trace")
+  -o, --output string                  Output file (default "./output.trace")
       --pod-name string                Target pod
   -p, --process-id int                 The process ID to collect the trace from (default 1)
       --profile profile                A named pre-defined set of provider configurations that allowscommon tracing scenarios to be specified succinctly.

--- a/cli/docs/kubectl-shovel_version.md
+++ b/cli/docs/kubectl-shovel_version.md
@@ -2,10 +2,6 @@
 
 Print your cli version
 
-### Synopsis
-
-Print your cli version
-
 ```
 kubectl-shovel version [flags]
 ```

--- a/dumper/cmd/gcdump.go
+++ b/dumper/cmd/gcdump.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"strconv"
-
+	"github.com/dodopizza/kubectl-shovel/internal/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -12,17 +11,11 @@ const (
 )
 
 type gcDumpOptions struct {
-	pid int
-}
-
-func newGCDumpOptions() *gcDumpOptions {
-	return &gcDumpOptions{
-		pid: 1,
-	}
+	*flags.GCDumpFlagSet
 }
 
 func newGCDumpCommand() *cobra.Command {
-	options := newGCDumpOptions()
+	options := &gcDumpOptions{}
 	cmd := &cobra.Command{
 		Use:   "gcdump [flags]",
 		Args:  cobra.NoArgs,
@@ -43,16 +36,21 @@ func newGCDumpCommand() *cobra.Command {
 }
 
 func (options *gcDumpOptions) parseFlags() *pflag.FlagSet {
-	flags := pflag.NewFlagSet("gcdump", pflag.ExitOnError)
+	flagSet := pflag.NewFlagSet("gcdump", pflag.ExitOnError)
 
-	return flags
+	options.GCDumpFlagSet = flags.NewGCDumpFlagSet()
+	flagSet.AddFlagSet(options.GCDumpFlagSet.Parse())
+
+	return flagSet
 }
 
 func makeGCDump(options *gcDumpOptions) error {
+	args := append(
+		[]string{"collect"},
+		options.Args()...,
+	)
 	return launch(
 		dotnetGCDumpBinary,
-		"collect",
-		"--process-id",
-		strconv.Itoa(options.pid),
+		args...,
 	)
 }

--- a/dumper/cmd/launch.go
+++ b/dumper/cmd/launch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -54,7 +55,9 @@ func launch(executable string, args ...string) error {
 		output,
 	)
 
-	if err := watchdog.Watch(); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := watchdog.Watch(ctx); err != nil {
 		events.NewEvent(
 			events.Error,
 			err.Error(),

--- a/dumper/cmd/trace.go
+++ b/dumper/cmd/trace.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"strconv"
-
+	"github.com/dodopizza/kubectl-shovel/internal/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -12,17 +11,11 @@ const (
 )
 
 type traceOptions struct {
-	pid int
-}
-
-func newTraceOptions() *traceOptions {
-	return &traceOptions{
-		pid: 1,
-	}
+	*flags.TraceFlagSet
 }
 
 func newTraceCommand() *cobra.Command {
-	options := newTraceOptions()
+	options := &traceOptions{}
 	cmd := &cobra.Command{
 		Use:   "trace [flags]",
 		Args:  cobra.NoArgs,
@@ -43,18 +36,21 @@ func newTraceCommand() *cobra.Command {
 }
 
 func (options *traceOptions) parseFlags() *pflag.FlagSet {
-	flags := pflag.NewFlagSet("trace", pflag.ExitOnError)
+	flagSet := pflag.NewFlagSet("trace", pflag.ExitOnError)
 
-	return flags
+	options.TraceFlagSet = flags.NewTraceFlagSet()
+	flagSet.AddFlagSet(options.TraceFlagSet.Parse())
+
+	return flagSet
 }
 
 func makeTrace(options *traceOptions) error {
+	args := append(
+		[]string{"collect"},
+		options.Args()...,
+	)
 	return launch(
 		dotnetTraceBinary,
-		"collect",
-		"--process-id",
-		strconv.Itoa(options.pid),
-		"--duration",
-		"00:00:00:10",
+		args...,
 	)
 }

--- a/hacks/run-doc-generation.sh
+++ b/hacks/run-doc-generation.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ./cli
+go run . doc

--- a/hacks/run-doc-generation.sh
+++ b/hacks/run-doc-generation.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 cd ./cli
-go run . doc
+go build \
+  -o ./bin/kubectl-shovel \
+  .
+
+HOME="/home/user" ./bin/kubectl-shovel doc

--- a/hacks/run-integration-tests.sh
+++ b/hacks/run-integration-tests.sh
@@ -35,7 +35,7 @@ kind load docker-image ${image_repository}:${image_tag}
 echo "Running tests..."
 go test -v \
   --tags=integration \
-  -timeout 100s \
+  -timeout 300s \
   ./test/integration/... | \
   sed "/PASS/s//$(printf "\033[32mPASS\033[0m")/" | \
   sed "/FAIL/s//$(printf "\033[31mFAIL\033[0m")/"

--- a/internal/flags/clreventlevel.go
+++ b/internal/flags/clreventlevel.go
@@ -1,0 +1,44 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CLREventLevel string
+
+var supportedCLREventLevels = []string{
+	"logalways",
+	"critical",
+	"error",
+	"warning",
+	"informational",
+	"verbose",
+}
+
+func (c *CLREventLevel) String() string {
+	return string(*c)
+}
+
+func (c *CLREventLevel) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("no CLR Event Level given, must be one of: [%s]",
+			strings.Join(supportedCLREventLevels, ", "))
+	}
+	if !ContainsItemString(supportedCLREventLevels, str) {
+		return fmt.Errorf("unsupported CLR Event Level \"%s\", must be one of: [%s]",
+			str, strings.Join(supportedCLREventLevels, ", "))
+
+	}
+	*c = CLREventLevel(str)
+	return nil
+}
+
+func (c *CLREventLevel) Type() string {
+	return "clreventlevel"
+}
+
+func (c *CLREventLevel) Description() string {
+	return "Verbosity of CLR events to be emitted. Supported levels:\n" +
+		strings.Join(supportedCLREventLevels, ", ")
+}

--- a/internal/flags/clrevents.go
+++ b/internal/flags/clrevents.go
@@ -1,0 +1,35 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CLREvents []string
+
+const (
+	CLREventsDelimiter = "+"
+)
+
+func (c *CLREvents) String() string {
+	return strings.Join(*c, CLREventsDelimiter)
+}
+
+func (c *CLREvents) Set(str string) error {
+	events := strings.Split(str, CLREventsDelimiter)
+	*c = events
+	return nil
+}
+
+func (c *CLREvents) Type() string {
+	return "clrevents"
+}
+
+func (c *CLREvents) Description() string {
+	return fmt.Sprintf(
+		"A list of CLR runtime provider keywords to enable separated by \"%s\" signs.\n"+
+			"This is a simple mapping that lets you specify event keywords via string aliases rather than their hex values.\n"+
+			"More info here: https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace#options-1",
+		CLREventsDelimiter,
+	)
+}

--- a/internal/flags/clrevents.go
+++ b/internal/flags/clrevents.go
@@ -16,6 +16,9 @@ func (c *CLREvents) String() string {
 }
 
 func (c *CLREvents) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("passed empty CLR Events")
+	}
 	events := strings.Split(str, CLREventsDelimiter)
 	*c = events
 	return nil

--- a/internal/flags/dotnet_tools.go
+++ b/internal/flags/dotnet_tools.go
@@ -1,0 +1,36 @@
+package flags
+
+import (
+	"strconv"
+
+	"github.com/spf13/pflag"
+)
+
+type DotnetToolsFlagSet struct {
+	ProcessID int
+}
+
+func NewDotnetToolsFlagSet() *DotnetToolsFlagSet {
+	return &DotnetToolsFlagSet{
+		ProcessID: 1,
+	}
+}
+
+func (dt *DotnetToolsFlagSet) Parse() *pflag.FlagSet {
+	flagSet := pflag.NewFlagSet("dotnet-tools", pflag.ExitOnError)
+	flagSet.IntVarP(
+		&dt.ProcessID,
+		"process-id",
+		"p",
+		dt.ProcessID,
+		"The process ID to collect the trace from",
+	)
+
+	return flagSet
+}
+
+func (dt *DotnetToolsFlagSet) Args() []string {
+	return []string{
+		"--process-id", strconv.Itoa(dt.ProcessID),
+	}
+}

--- a/internal/flags/duration.go
+++ b/internal/flags/duration.go
@@ -1,0 +1,43 @@
+package flags
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Duration string
+
+var defaultDuration = "00:00:00:10"
+
+func (d *Duration) String() string {
+	return string(*d)
+}
+
+func (d *Duration) Set(str string) error {
+	split := strings.Split(str, ":")
+	if len(split) != 4 {
+		return fmt.Errorf(
+			"wrong duration format provided \"%s\", should be \"dd:hh:mm:ss\"",
+			str,
+		)
+	}
+	for _, s := range split {
+		if _, err := strconv.Atoi(s); err != nil {
+			return fmt.Errorf(
+				"wrong duration format provided \"%s\", should be \"dd:hh:mm:ss\"",
+				str,
+			)
+		}
+	}
+	*d = Duration(str)
+	return nil
+}
+
+func (d *Duration) Type() string {
+	return "duration"
+}
+
+func (d *Duration) Description() string {
+	return "Trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss"
+}

--- a/internal/flags/duration.go
+++ b/internal/flags/duration.go
@@ -4,17 +4,47 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
-type Duration string
+type Duration time.Duration
 
-var defaultDuration = "00:00:00:10"
+var (
+	defaultDuration = 10 * time.Second
+	day             = 24 * time.Hour
+	unitPosition    = map[int]time.Duration{
+		0: 24 * time.Hour,
+		1: time.Hour,
+		2: time.Minute,
+		3: time.Second,
+	}
+)
 
 func (d *Duration) String() string {
-	return string(*d)
+	m := time.Duration(*d)
+	days := m / day
+	m -= days * day
+	hours := m / time.Hour
+	m -= hours * time.Hour
+	minutes := m / time.Minute
+	m -= minutes * time.Minute
+	seconds := m / time.Second
+	return fmt.Sprintf(
+		"%02d:%02d:%02d:%02d",
+		days, hours, minutes, seconds,
+	)
 }
 
 func (d *Duration) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("empty duration passed")
+	}
+	m, err := time.ParseDuration(str)
+	if err == nil {
+		*d = Duration(m)
+		return d.checkDuration()
+	}
+
 	split := strings.Split(str, ":")
 	if len(split) != 4 {
 		return fmt.Errorf(
@@ -22,15 +52,24 @@ func (d *Duration) Set(str string) error {
 			str,
 		)
 	}
-	for _, s := range split {
-		if _, err := strconv.Atoi(s); err != nil {
+	for i := range split {
+		n, err := strconv.Atoi(split[i])
+		if err != nil {
 			return fmt.Errorf(
-				"wrong duration format provided \"%s\", should be \"dd:hh:mm:ss\"",
+				"not a number value provided for duration: \"%s\"",
 				str,
 			)
 		}
+		m += time.Duration(n) * unitPosition[i]
 	}
-	*d = Duration(str)
+	*d = Duration(m)
+	return d.checkDuration()
+}
+
+func (d *Duration) checkDuration() error {
+	if time.Duration(*d) < (1 * time.Second) {
+		return fmt.Errorf("provided duration is to low, minimum 1 second")
+	}
 	return nil
 }
 
@@ -39,5 +78,10 @@ func (d *Duration) Type() string {
 }
 
 func (d *Duration) Description() string {
-	return "Trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss"
+	return "Trace for the given timespan and then automatically stop the trace." +
+		fmt.Sprintf(
+			"Provided in the form of dd:hh:mm:ss or "+
+				"corresponding time unit representation (e.g. 1s, 2m, 3h) (default %s)",
+			defaultDuration,
+		)
 }

--- a/internal/flags/format.go
+++ b/internal/flags/format.go
@@ -1,0 +1,45 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Format string
+
+var (
+	defaultFormat    = "NetTrace"
+	supportedFormats = []string{
+		defaultFormat,
+		"Chromium",
+		"Speedscope",
+	}
+)
+
+func (f *Format) String() string {
+	return string(*f)
+}
+
+func (f *Format) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("no format given, must be one of: [%s]",
+			strings.Join(supportedFormats, ", "))
+	}
+	if !ContainsItemString(supportedFormats, str) {
+		return fmt.Errorf("unsupported format \"%s\", must be one of: [%s]",
+			str, strings.Join(supportedFormats, ", "))
+
+	}
+	*f = Format(str)
+	return nil
+}
+
+func (f *Format) Type() string {
+	return "format"
+}
+
+func (f *Format) Description() string {
+	return "Sets the output format for the trace file conversion. Supported formats:\n" +
+		strings.Join(supportedFormats, ", ") +
+		fmt.Sprintf(" (default \"%s\")", defaultFormat)
+}

--- a/internal/flags/gcdump_flagset.go
+++ b/internal/flags/gcdump_flagset.go
@@ -1,13 +1,11 @@
 package flags
 
 import (
-	"strconv"
-
 	"github.com/spf13/pflag"
 )
 
 type GCDumpFlagSet struct {
-	Timeout int
+	Timeout Timeout
 	dt      *DotnetToolsFlagSet
 
 	flagSet *pflag.FlagSet
@@ -23,11 +21,10 @@ func NewGCDumpFlagSet() *GCDumpFlagSet {
 func (gc *GCDumpFlagSet) Parse() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("dotnet-gcdump", pflag.ExitOnError)
 	flagSet.AddFlagSet(gc.dt.Parse())
-	flagSet.IntVar(
+	flagSet.Var(
 		&gc.Timeout,
-		"timeout",
-		gc.Timeout,
-		"Give up on collecting the GC dump if it takes longer than this many seconds",
+		gc.Timeout.Type(),
+		gc.Timeout.Description(),
 	)
 
 	gc.flagSet = flagSet
@@ -36,12 +33,10 @@ func (gc *GCDumpFlagSet) Parse() *pflag.FlagSet {
 
 func (gc *GCDumpFlagSet) Args() []string {
 	args := gc.dt.Args()
-	if gc.flagSet.Changed("timeout") {
+	if gc.flagSet.Changed(gc.Timeout.Type()) {
 		args = append(
 			args,
-			[]string{
-				"--timeout", strconv.Itoa(gc.Timeout),
-			}...,
+			FlagToArg(&gc.Timeout)...,
 		)
 	}
 	return args

--- a/internal/flags/gcdump_flagset.go
+++ b/internal/flags/gcdump_flagset.go
@@ -1,0 +1,48 @@
+package flags
+
+import (
+	"strconv"
+
+	"github.com/spf13/pflag"
+)
+
+type GCDumpFlagSet struct {
+	Timeout int
+	dt      *DotnetToolsFlagSet
+
+	flagSet *pflag.FlagSet
+}
+
+func NewGCDumpFlagSet() *GCDumpFlagSet {
+	return &GCDumpFlagSet{
+		Timeout: 30,
+		dt:      NewDotnetToolsFlagSet(),
+	}
+}
+
+func (gc *GCDumpFlagSet) Parse() *pflag.FlagSet {
+	flagSet := pflag.NewFlagSet("dotnet-gcdump", pflag.ExitOnError)
+	flagSet.AddFlagSet(gc.dt.Parse())
+	flagSet.IntVar(
+		&gc.Timeout,
+		"timeout",
+		gc.Timeout,
+		"Give up on collecting the GC dump if it takes longer than this many seconds",
+	)
+
+	gc.flagSet = flagSet
+	return flagSet
+}
+
+func (gc *GCDumpFlagSet) Args() []string {
+	args := gc.dt.Args()
+	if gc.flagSet.Changed("timeout") {
+		args = append(
+			args,
+			[]string{
+				"--timeout", strconv.Itoa(gc.Timeout),
+			}...,
+		)
+	}
+	return args
+}

--- a/internal/flags/gcdump_flagset_test.go
+++ b/internal/flags/gcdump_flagset_test.go
@@ -1,0 +1,143 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GCDumpFlagSet(t *testing.T) {
+	testCases := []struct {
+		name    string
+		args    []string
+		expArgs []string
+	}{
+		{
+			name: "Defaults",
+			args: []string{},
+			expArgs: []string{
+				"--process-id", "1",
+			},
+		},
+		{
+			name: "Override process ID",
+			args: []string{
+				"--process-id", "5",
+			},
+			expArgs: []string{
+				"--process-id", "5",
+			},
+		},
+		{
+			name: "Override timeout",
+			args: []string{
+				"--timeout", "120",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--timeout", "120",
+			},
+		},
+		{
+			name: "Override timeout in seconds",
+			args: []string{
+				"--timeout", "120s",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--timeout", "120",
+			},
+		},
+		{
+			name: "Override timeout in minutes",
+			args: []string{
+				"--timeout", "2m",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--timeout", "120",
+			},
+		},
+		{
+			name: "Override timeout with milliseconds",
+			args: []string{
+				"--timeout", "60s50ms",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--timeout", "60",
+			},
+		},
+		{
+			name: "Override timeout and process id",
+			args: []string{
+				"--process-id", "5",
+				"--timeout", "10m",
+			},
+			expArgs: []string{
+				"--process-id", "5",
+				"--timeout", "600",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			gc := NewGCDumpFlagSet()
+			flagSet.AddFlagSet(gc.Parse())
+
+			require.NoError(t, flagSet.Parse(tc.args))
+			require.Equal(t, tc.expArgs, gc.Args())
+		})
+	}
+}
+
+func Test_GCDumpFlagSet_Errors(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "Bad process ID",
+			args: []string{
+				"--process-id", "a",
+			},
+		},
+		{
+			name: "Empty process ID",
+			args: []string{
+				"--process-id", "",
+			},
+		},
+		{
+			name: "Bad timeout",
+			args: []string{
+				"--timeout", "abc",
+			},
+		},
+		{
+			name: "Low timeout",
+			args: []string{
+				"--timeout", "5ms",
+			},
+		},
+		{
+			name: "Empty timeout",
+			args: []string{
+				"--timeout", "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			gc := NewGCDumpFlagSet()
+			flagSet.AddFlagSet(gc.Parse())
+
+			require.Error(t, flagSet.Parse(tc.args))
+		})
+	}
+}

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -1,0 +1,23 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+func ContainsItemString(strs []string, item string) bool {
+	for _, str := range strs {
+		if str == item {
+			return true
+		}
+	}
+	return false
+}
+
+func FlagToArg(flag pflag.Value) []string {
+	return []string{
+		fmt.Sprintf("--%s", flag.Type()),
+		flag.String(),
+	}
+}

--- a/internal/flags/profile.go
+++ b/internal/flags/profile.go
@@ -1,0 +1,45 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Profile string
+
+var (
+	supportedProfiles = []string{
+		"cpu-sampling",
+		"gc-verbose",
+		"gc-collect",
+	}
+)
+
+func (p *Profile) String() string {
+	return string(*p)
+}
+
+func (p *Profile) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("no profile given, must be one of: [%s]",
+			strings.Join(supportedProfiles, ", "))
+	}
+	if !ContainsItemString(supportedProfiles, str) {
+		return fmt.Errorf("unsupported profile \"%s\", must be one of: [%s]",
+			str, strings.Join(supportedProfiles, ", "))
+
+	}
+	*p = Profile(str)
+	return nil
+}
+
+func (p *Profile) Type() string {
+	return "profile"
+}
+
+func (p *Profile) Description() string {
+	return "A named pre-defined set of provider configurations that allows" +
+		"common tracing scenarios to be specified succinctly.\n" +
+		"The following profiles are available:\n" +
+		strings.Join(supportedProfiles, ", ")
+}

--- a/internal/flags/providers.go
+++ b/internal/flags/providers.go
@@ -1,0 +1,36 @@
+package flags
+
+import "strings"
+
+type Providers []string
+
+const (
+	ProvidersDelimiter = ","
+)
+
+func (p *Providers) String() string {
+	return strings.Join(*p, ProvidersDelimiter)
+}
+
+func (p *Providers) Set(str string) error {
+	providers := strings.Split(str, ProvidersDelimiter)
+	*p = providers
+	return nil
+}
+
+func (p *Providers) Description() string {
+	return "A comma-separated list of EventPipe providers to be enabled.\n" +
+		"These providers supplement any providers implied by --profile <profile-name>.\n" +
+		"If there's any inconsistency for a particular provider,\n" +
+		"this configuration takes precedence over the implicit configuration from the profile.\n\n" +
+		"This list of providers is in the form:\n\n" +
+		"* Provider[,Provider]\n" +
+		"* Provider is in the form: KnownProviderName[:Flags[:Level][:KeyValueArgs]].\n" +
+		"* KeyValueArgs is in the form: [key1=value1][;key2=value2].\n\n" +
+		"To learn more about some of the well-known providers in .NET, refer to:\n" +
+		"https://docs.microsoft.com/en-us/dotnet/core/diagnostics/well-known-event-providers"
+}
+
+func (p *Providers) Type() string {
+	return "providers"
+}

--- a/internal/flags/providers.go
+++ b/internal/flags/providers.go
@@ -1,6 +1,9 @@
 package flags
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type Providers []string
 
@@ -13,6 +16,9 @@ func (p *Providers) String() string {
 }
 
 func (p *Providers) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("empty providers given")
+	}
 	providers := strings.Split(str, ProvidersDelimiter)
 	*p = providers
 	return nil

--- a/internal/flags/timeout.go
+++ b/internal/flags/timeout.go
@@ -1,0 +1,57 @@
+package flags
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Timeout time.Duration
+
+func (t *Timeout) String() string {
+	return fmt.Sprintf(
+		"%.0f",
+		time.Duration(*t).
+			Seconds(),
+	)
+}
+
+func (t *Timeout) Set(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("empty timeout passed")
+	}
+	d, err := time.ParseDuration(str)
+	if err == nil {
+		*t = Timeout(d)
+		return t.checkDuration()
+	}
+	i, err := strconv.Atoi(str)
+	if err == nil {
+		*t = Timeout(time.Duration(i) * time.Second)
+		return t.checkDuration()
+	}
+
+	return fmt.Errorf(
+		"can't parse duration from %s, provide it as number to define seconds or with units",
+		str,
+	)
+}
+
+func (t *Timeout) checkDuration() error {
+	if time.Duration(*t) < (1 * time.Second) {
+		return fmt.Errorf("provided duration is to low, minimum 1 second")
+	}
+	return nil
+}
+
+func (t *Timeout) Type() string {
+	return "timeout"
+}
+
+func (t *Timeout) Description() string {
+	return "Give up on collecting the GC dump if it takes longer than this many seconds.\n" +
+		"Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".\n" +
+		"Will be rounded to seconds. If no unit provided defaults to seconds.\n" +
+		"(default 30 sec)"
+}

--- a/internal/flags/trace_flagset.go
+++ b/internal/flags/trace_flagset.go
@@ -1,0 +1,134 @@
+package flags
+
+import (
+	"strconv"
+
+	"github.com/spf13/pflag"
+)
+
+type TraceFlagSet struct {
+	BufferSize    int
+	CLREventLevel CLREventLevel
+	CLREvents     CLREvents
+	Duration      Duration
+	Format        Format
+	Profile       Profile
+	Providers     Providers
+
+	dt *DotnetToolsFlagSet
+
+	flagSet *pflag.FlagSet
+}
+
+func NewTraceFlagSet() *TraceFlagSet {
+	return &TraceFlagSet{
+		BufferSize: 256,
+		dt:         NewDotnetToolsFlagSet(),
+	}
+}
+
+func (trace *TraceFlagSet) Parse() *pflag.FlagSet {
+	flagSet := pflag.NewFlagSet("dotnet-trace", pflag.ExitOnError)
+	flagSet.AddFlagSet(trace.dt.Parse())
+	flagSet.IntVar(
+		&trace.BufferSize,
+		"buffersize",
+		trace.BufferSize,
+		"Sets the size of the in-memory circular buffer, in megabytes",
+	)
+
+	flagSet.Var(
+		&trace.CLREventLevel,
+		trace.CLREventLevel.Type(),
+		trace.CLREventLevel.Description(),
+	)
+
+	flagSet.Var(
+		&trace.CLREvents,
+		trace.CLREvents.Type(),
+		trace.CLREvents.Description(),
+	)
+
+	trace.Duration = Duration(defaultDuration)
+	flagSet.Var(
+		&trace.Duration,
+		trace.Duration.Type(),
+		trace.Duration.Description(),
+	)
+
+	flagSet.Var(
+		&trace.Format,
+		trace.Format.Type(),
+		trace.Format.Description(),
+	)
+
+	flagSet.Var(
+		&trace.Profile,
+		trace.Profile.Type(),
+		trace.Profile.Description(),
+	)
+
+	flagSet.Var(
+		&trace.Providers,
+		trace.Providers.Type(),
+		trace.Providers.Description(),
+	)
+
+	trace.flagSet = flagSet
+	return flagSet
+}
+
+func (trace *TraceFlagSet) Args() []string {
+	args := trace.dt.Args()
+
+	if trace.flagSet.Changed("buffersize") {
+		args = append(
+			args,
+			[]string{
+				"--buffersize", strconv.Itoa(trace.BufferSize),
+			}...,
+		)
+	}
+
+	if trace.flagSet.Changed(trace.CLREventLevel.Type()) {
+		args = append(
+			args,
+			FlagToArg(&trace.CLREventLevel)...,
+		)
+	}
+
+	if trace.flagSet.Changed(trace.CLREvents.Type()) {
+		args = append(
+			args,
+			FlagToArg(&trace.CLREvents)...,
+		)
+	}
+
+	args = append(
+		args,
+		FlagToArg(&trace.Duration)...,
+	)
+
+	if trace.flagSet.Changed(trace.Format.Type()) {
+		args = append(
+			args,
+			FlagToArg(&trace.Format)...,
+		)
+	}
+
+	if trace.flagSet.Changed(trace.Profile.Type()) {
+		args = append(
+			args,
+			FlagToArg(&trace.Profile)...,
+		)
+	}
+
+	if trace.flagSet.Changed(trace.Providers.Type()) {
+		args = append(
+			args,
+			FlagToArg(&trace.Providers)...,
+		)
+	}
+
+	return args
+}

--- a/internal/flags/trace_flagset_test.go
+++ b/internal/flags/trace_flagset_test.go
@@ -1,0 +1,312 @@
+package flags
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TestFlagSet(t *testing.T) {
+	testCases := []struct {
+		name    string
+		args    []string
+		expArgs []string
+	}{
+		{
+			name: "Defaults",
+			args: []string{},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:00:10",
+			},
+		},
+		{
+			name: "Override process ID",
+			args: []string{
+				"--process-id", "5",
+			},
+			expArgs: []string{
+				"--process-id", "5",
+				"--duration", "00:00:00:10",
+			},
+		},
+		{
+			name: "Override buffersize",
+			args: []string{
+				"--buffersize", "1024",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--buffersize", "1024",
+				"--duration", "00:00:00:10",
+			},
+		},
+		{
+			name: "Override buffersize",
+			args: []string{
+				"--clreventlevel", "warning",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--clreventlevel", "warning",
+				"--duration", "00:00:00:10",
+			},
+		},
+		{
+			name: "Override buffersize",
+			args: []string{
+				"--clrevents", "gc+gchandle",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--clrevents", "gc+gchandle",
+				"--duration", "00:00:00:10",
+			},
+		},
+		{
+			name: "1 minute duration",
+			args: []string{
+				"--duration", "00:00:01:00",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:01:00",
+			},
+		},
+		{
+			name: "5 days duration and 1 minute",
+			args: []string{
+				"--duration", "05:00:01:00",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "05:00:01:00",
+			},
+		},
+		{
+			name: "1 minute duration with units",
+			args: []string{
+				"--duration", "1m",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:01:00",
+			},
+		},
+		{
+			name: "Duration with multiple units",
+			args: []string{
+				"--duration", "5h10s",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:05:00:10",
+			},
+		},
+		{
+			name: "Duration with ms units",
+			args: []string{
+				"--duration", "5m50ms",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:05:00",
+			},
+		},
+		{
+			name: "Override duration with units",
+			args: []string{
+				"--duration", "1m",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:01:00",
+			},
+		},
+		{
+			name: "Override format",
+			args: []string{
+				"--format", "Speedscope",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:00:10",
+				"--format", "Speedscope",
+			},
+		},
+		{
+			name: "Override profile",
+			args: []string{
+				"--profile", "gc-verbose",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:00:10",
+				"--profile", "gc-verbose",
+			},
+		},
+		{
+			name: "Override providers",
+			args: []string{
+				"--providers",
+				strings.Join(
+					[]string{
+						"System.Runtime:0:1:EventCounterIntervalSec=1",
+						"Microsoft-Windows-DotNETRuntime:0:1",
+						"Microsoft-DotNETCore-SampleProfiler:0:1",
+					},
+					",",
+				),
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:00:10",
+				"--providers",
+				strings.Join(
+					[]string{
+						"System.Runtime:0:1:EventCounterIntervalSec=1",
+						"Microsoft-Windows-DotNETRuntime:0:1",
+						"Microsoft-DotNETCore-SampleProfiler:0:1",
+					},
+					",",
+				),
+			},
+		},
+		{
+			name: "Override profile",
+			args: []string{
+				"--profile", "gc-verbose",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--duration", "00:00:00:10",
+				"--profile", "gc-verbose",
+			},
+		},
+		{
+			name: "Set multiple flags",
+			args: []string{
+				"--buffersize", "1024",
+				"--duration", "00:00:01:00",
+				"--format", "Speedscope",
+				"--profile", "gc-verbose",
+			},
+			expArgs: []string{
+				"--process-id", "1",
+				"--buffersize", "1024",
+				"--duration", "00:00:01:00",
+				"--format", "Speedscope",
+				"--profile", "gc-verbose",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			trace := NewTraceFlagSet()
+			flagSet.AddFlagSet(trace.Parse())
+
+			require.NoError(t, flagSet.Parse(tc.args))
+			require.Equal(t, tc.expArgs, trace.Args())
+		})
+	}
+}
+
+func Test_TraceFlagSet_Errors(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "Bad process ID",
+			args: []string{
+				"--process-id", "a",
+			},
+		},
+		{
+			name: "Bad buffersize",
+			args: []string{
+				"--buffersize", "wrong",
+			},
+		},
+		{
+			name: "Bad CLR Event Level",
+			args: []string{
+				"--clreventlevel", "high",
+			},
+		},
+		{
+			name: "Empty CLR Event Level",
+			args: []string{
+				"--clreventlevel", "",
+			},
+		},
+		{
+			name: "Empty CLR Events",
+			args: []string{
+				"--clrevents", "",
+			},
+		},
+		{
+			name: "Wrong duration format",
+			args: []string{
+				"--duration", "00:00:00",
+			},
+		},
+		{
+			name: "Not numbers in duration",
+			args: []string{
+				"--duration", "00:00:00:aa",
+			},
+		},
+		{
+			name: "Empty duration",
+			args: []string{
+				"--duration", "",
+			},
+		},
+		{
+			name: "Wrong format",
+			args: []string{
+				"--format", "Scopespeed",
+			},
+		},
+		{
+			name: "Empty format",
+			args: []string{
+				"--format", "",
+			},
+		},
+		{
+			name: "Wrong profile",
+			args: []string{
+				"--profile", "a4",
+			},
+		},
+		{
+			name: "Empty profile",
+			args: []string{
+				"--profile", "",
+			},
+		},
+		{
+			name: "Empty providers",
+			args: []string{
+				"--providers", "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			trace := NewTraceFlagSet()
+			flagSet.AddFlagSet(trace.Parse())
+
+			require.Error(t, flagSet.Parse(tc.args))
+		})
+	}
+}

--- a/internal/flags/trace_flagset_test.go
+++ b/internal/flags/trace_flagset_test.go
@@ -263,6 +263,18 @@ func Test_TraceFlagSet_Errors(t *testing.T) {
 			},
 		},
 		{
+			name: "Just numbers in duration",
+			args: []string{
+				"--duration", "100",
+			},
+		},
+		{
+			name: "Too low duration",
+			args: []string{
+				"--duration", "100ms",
+			},
+		},
+		{
 			name: "Empty duration",
 			args: []string{
 				"--duration", "",

--- a/test/integration/gcdump_test.go
+++ b/test/integration/gcdump_test.go
@@ -26,6 +26,14 @@ func Test_GCDumpSubcommand(t *testing.T) {
 			pod:  sampleAppPod(),
 		},
 		{
+			name: "Custom timeout",
+			args: []string{
+				"--timeout",
+				"60",
+			},
+			pod: sampleAppPod(),
+		},
+		{
 			name: "Multicontainer pod",
 			args: []string{
 				"--container",

--- a/test/integration/gcdump_test.go
+++ b/test/integration/gcdump_test.go
@@ -34,6 +34,14 @@ func Test_GCDumpSubcommand(t *testing.T) {
 			pod: sampleAppPod(),
 		},
 		{
+			name: "Custom timeout with unit",
+			args: []string{
+				"--timeout",
+				"1m",
+			},
+			pod: sampleAppPod(),
+		},
+		{
 			name: "Multicontainer pod",
 			args: []string{
 				"--container",

--- a/test/integration/trace_test.go
+++ b/test/integration/trace_test.go
@@ -26,6 +26,22 @@ func Test_TraceSubcommand(t *testing.T) {
 			pod:  sampleAppPod(),
 		},
 		{
+			name: "Custom duration",
+			args: []string{
+				"--duration",
+				"00:00:00:15",
+			},
+			pod: sampleAppPod(),
+		},
+		{
+			name: "Custom format",
+			args: []string{
+				"--format",
+				"Speedscope",
+			},
+			pod: sampleAppPod(),
+		},
+		{
 			name: "Multicontainer pod",
 			args: []string{
 				"--container",

--- a/test/integration/trace_test.go
+++ b/test/integration/trace_test.go
@@ -29,7 +29,15 @@ func Test_TraceSubcommand(t *testing.T) {
 			name: "Custom duration",
 			args: []string{
 				"--duration",
-				"00:00:00:15",
+				"00:00:00:30",
+			},
+			pod: sampleAppPod(),
+		},
+		{
+			name: "Custom duration with units",
+			args: []string{
+				"--duration",
+				"1m",
 			},
 			pod: sampleAppPod(),
 		},


### PR DESCRIPTION
Mostly related to #3. It adds support for custom flags like `--duration`, `--format`, etc.

PID is not determined automatically, but there is option to override `--process-id` as temporary solution.