### PR TITLE
Feature/darwin arm build support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,10 @@ builds:
   - darwin
   goarch:
   - amd64
+  - arm64
+  ignore:
+  - goos: windows
+    goarch: arm64
 
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -29,6 +29,17 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
+    - {{addURIAndSha "https://github.com/dodopizza/kubectl-shovel/releases/download/{{ .TagName }}/kubectl-shovel_Darwin_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-shovel
+      files:
+        - from: kubectl-shovel
+          to: .
+        - from: LICENSE
+          to: .
+      selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
     - {{addURIAndSha "https://github.com/dodopizza/kubectl-shovel/releases/download/{{ .TagName }}/kubectl-shovel_Linux_x86_64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-shovel
       files:
@@ -40,6 +51,17 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
+    - {{addURIAndSha "https://github.com/dodopizza/kubectl-shovel/releases/download/{{ .TagName }}/kubectl-shovel_Linux_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-shovel
+      files:
+        - from: kubectl-shovel
+          to: .
+        - from: LICENSE
+          to: .
+      selector:
+        matchLabels:
+          os: linux
+          arch: arm64
     - {{addURIAndSha "https://github.com/dodopizza/kubectl-shovel/releases/download/{{ .TagName }}/kubectl-shovel_Windows_x86_64.zip" .TagName | indent 6 }}
       bin: kubectl-shovel.exe
       files:


### PR DESCRIPTION
Support for OS X and Linux (arm64 arch).
Currently ignore Windows-arm64 cause compilation fails with: 

```
   ⨯ release failed after 3.62s error=failed to build for windows_arm64: exit status 2: # golang.org/x/sys/windows
../../pkg/mod/golang.org/x/sys@v0.0.0-20201112073958-5cba982894dd/windows/types_windows.go:1597:24: undefined: JOBOBJECT_BASIC_LIMIT_INFORMATION
../../pkg/mod/golang.org/x/sys@v0.0.0-20201112073958-5cba982894dd/windows/zsyscall_windows.go:2877:38: undefined: WSAData
../../pkg/mod/golang.org/x/sys@v0.0.0-20201112073958-5cba982894dd/windows/zsyscall_windows.go:2953:51: undefined: Servent
../../pkg/mod/golang.org/x/sys@v0.0.0-20201112073958-5cba982894dd/windows/zsyscall_windows.go:2967:50: undefined: Servent
```