### PR TITLE
Feature: Add resource limitation arguments

### DIFF
--- a/cli/cmd/command_builder.go
+++ b/cli/cmd/command_builder.go
@@ -20,6 +20,8 @@ type CommonOptions struct {
 	Pod               string
 	Output            string
 	OutputHostPath    string
+	LimitCpu          string
+	LimitMemory       string
 	StoreOutputOnHost bool
 
 	kubeConfig *genericclioptions.ConfigFlags
@@ -67,6 +69,18 @@ func (options *CommonOptions) GetFlags() *pflag.FlagSet {
 		"output-host-path",
 		options.OutputHostPath,
 		"Host folder, where will be stored artifact",
+	)
+	fs.StringVar(
+		&options.LimitCpu,
+		"limit-cpu",
+		options.LimitCpu,
+		"Limit maximal consumptions cpu for the executing job",
+	)
+	fs.StringVar(
+		&options.LimitMemory,
+		"limit-memory",
+		options.LimitMemory,
+		"Limit maximal consumptions memory for the executing job",
 	)
 	fs.BoolVarP(
 		&options.StoreOutputOnHost,

--- a/cli/cmd/launch.go
+++ b/cli/cmd/launch.go
@@ -108,6 +108,10 @@ func (cb *CommandBuilder) launch() error {
 			WithHostProcVolume()
 	}
 
+	if cb.tool.IsLimitedResources() {
+		jobSpec.WithLimits(cb.CommonOptions.LimitCpu, cb.CommonOptions.LimitMemory)
+	}
+
 	fmt.Printf("Spawning diagnostics job with command:\n%s\n", strings.Join(jobSpec.Args, " "))
 	if err := cb.kube.RunJob(jobSpec); err != nil {
 		return errors.Wrap(err, "Failed to spawn diagnostics job")

--- a/cli/docs/kubectl-shovel_coredump.md
+++ b/cli/docs/kubectl-shovel_coredump.md
@@ -49,6 +49,8 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --image string                   Image of dumper to use for job (default "dodopizza/kubectl-shovel-dumper:undefined")
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --limit-cpu string               Limit maximal consumptions cpu for the executing job
+      --limit-memory string            Limit maximal consumptions memory for the executing job
   -n, --namespace string               If present, the namespace scope for this CLI request
   -o, --output string                  Output file (default "./output.coredump")
       --output-host-path string        Host folder, where will be stored artifact (default "/tmp/kubectl-shovel")

--- a/cli/docs/kubectl-shovel_dump.md
+++ b/cli/docs/kubectl-shovel_dump.md
@@ -50,6 +50,8 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --image string                   Image of dumper to use for job (default "dodopizza/kubectl-shovel-dumper:undefined")
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --limit-cpu string               Limit maximal consumptions cpu for the executing job
+      --limit-memory string            Limit maximal consumptions memory for the executing job
   -n, --namespace string               If present, the namespace scope for this CLI request
   -o, --output string                  Output file (default "./output.dump")
       --output-host-path string        Host folder, where will be stored artifact (default "/tmp/kubectl-shovel")

--- a/cli/docs/kubectl-shovel_gcdump.md
+++ b/cli/docs/kubectl-shovel_gcdump.md
@@ -49,6 +49,8 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --image string                   Image of dumper to use for job (default "dodopizza/kubectl-shovel-dumper:undefined")
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --limit-cpu string               Limit maximal consumptions cpu for the executing job
+      --limit-memory string            Limit maximal consumptions memory for the executing job
   -n, --namespace string               If present, the namespace scope for this CLI request
   -o, --output string                  Output file (default "./output.gcdump")
       --output-host-path string        Host folder, where will be stored artifact (default "/tmp/kubectl-shovel")

--- a/cli/docs/kubectl-shovel_trace.md
+++ b/cli/docs/kubectl-shovel_trace.md
@@ -58,6 +58,8 @@ Also use `-n`/`--namespace` if your pod is not in current context's namespace:
       --image string                   Image of dumper to use for job (default "dodopizza/kubectl-shovel-dumper:undefined")
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --limit-cpu string               Limit maximal consumptions cpu for the executing job
+      --limit-memory string            Limit maximal consumptions memory for the executing job
   -n, --namespace string               If present, the namespace scope for this CLI request
   -o, --output string                  Output file (default "./output.trace")
       --output-host-path string        Host folder, where will be stored artifact (default "/tmp/kubectl-shovel")

--- a/internal/flags/core_dump.go
+++ b/internal/flags/core_dump.go
@@ -65,3 +65,6 @@ func (*coredump) ToolName() string {
 func (*coredump) IsPrivileged() bool {
 	return true
 }
+func (*coredump) IsLimitedResources() bool {
+	return true
+}

--- a/internal/flags/dotnet_dump.go
+++ b/internal/flags/dotnet_dump.go
@@ -57,3 +57,7 @@ func (*dump) BinaryName() string {
 func (*dump) ToolName() string {
 	return "dump"
 }
+
+func (*dump) IsLimitedResources() bool {
+	return true
+}

--- a/internal/flags/dotnet_gcdump.go
+++ b/internal/flags/dotnet_gcdump.go
@@ -48,3 +48,7 @@ func (*gcdump) BinaryName() string {
 func (*gcdump) ToolName() string {
 	return "gcdump"
 }
+
+func (*gcdump) IsLimitedResources() bool {
+	return true
+}

--- a/internal/flags/dotnet_tool_interface.go
+++ b/internal/flags/dotnet_tool_interface.go
@@ -17,6 +17,7 @@ type DotnetTool interface {
 	BinaryName() string
 	ToolName() string
 	IsPrivileged() bool
+	IsLimitedResources() bool
 }
 
 type DotnetToolFlagsFormatter interface {

--- a/internal/flags/dotnet_trace.go
+++ b/internal/flags/dotnet_trace.go
@@ -117,3 +117,7 @@ func (*trace) BinaryName() string {
 func (*trace) ToolName() string {
 	return "trace"
 }
+
+func (*trace) IsLimitedResources() bool {
+	return true
+}

--- a/test/integration/core_dump_test.go
+++ b/test/integration/core_dump_test.go
@@ -16,6 +16,9 @@ func Test_CoreDumpSubcommand(t *testing.T) {
 	command := "coredump"
 	testCases := cases(
 		NewTestCase("Custom type").WithArgs("type", "Heap"),
+		NewTestCase("Limits memory and cpu").WithArgs("limit-cpu", "300m").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits memory").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits cpu").WithArgs("limit-cpu", "300m"),
 	)
 
 	t.Cleanup(testSetup(t, command))

--- a/test/integration/dotnet_dump_test.go
+++ b/test/integration/dotnet_dump_test.go
@@ -16,6 +16,9 @@ func Test_DumpSubcommand(t *testing.T) {
 	command := "dump"
 	testCases := cases(
 		NewTestCase("Custom type").WithArgs("type", "Heap"),
+		NewTestCase("Limits memory and cpu").WithArgs("limit-cpu", "300m").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits memory").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits cpu").WithArgs("limit-cpu", "300m"),
 	)
 
 	t.Cleanup(testSetup(t, command))

--- a/test/integration/dotnet_gcdump_test.go
+++ b/test/integration/dotnet_gcdump_test.go
@@ -17,6 +17,9 @@ func Test_GCDumpSubcommand(t *testing.T) {
 	testCases := cases(
 		NewTestCase("Custom timeout").WithArgs("timeout", "60"),
 		NewTestCase("Custom timeout with unit").WithArgs("timeout", "1m"),
+		NewTestCase("Limits memory and cpu").WithArgs("limit-cpu", "300m").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits memory").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits cpu").WithArgs("limit-cpu", "300m"),
 	)
 
 	t.Cleanup(testSetup(t, command))

--- a/test/integration/dotnet_trace_test.go
+++ b/test/integration/dotnet_trace_test.go
@@ -18,6 +18,9 @@ func Test_TraceSubcommand(t *testing.T) {
 		NewTestCase("Custom duration").WithArgs("duration", "00:00:00:30"),
 		NewTestCase("Custom duration with units").WithArgs("duration", "1m"),
 		NewTestCase("Custom format").WithArgs("format", "Speedscope"),
+		NewTestCase("Limits memory and cpu").WithArgs("limit-cpu", "300m").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits memory").WithArgs("limit-memory", "500Mi"),
+		NewTestCase("Limits cpu").WithArgs("limit-cpu", "300m"),
 	)
 
 	t.Cleanup(testSetup(t, command))


### PR DESCRIPTION
Added two arguments for all commands:
 --limit-cpu string               Limit maximal consumptions cpu for the executing job
 --limit-memory string        Limit maximal consumptions memory for the executing job

Some clusters may have a restriction on entity deployment without specifying resource consumption limits.